### PR TITLE
Playlists as m3u, Playlists with custom icons, Playlist editing, Scan looks for other m3u files, Toasts for errors, Early Spanish localization & i38n support

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,9 +17,8 @@
     <list default="true" id="152ba708-cd46-4fc3-ab0c-616e9212beb1" name="Changes" comment="Settings menu is mostly done, added progress bar for file scanning (a file is considered scanned only after it is checled for metadata currently which is only done after initially gathering a list of all the files, probably super inefficient and it looks like nothing is progressing to the user until initial scan is done)&#10;&#10;Signed-off-by: Samuel Rivero Luna &lt;riveroluna@protonmail.com&gt;">
       <changelist_data name="Samuel RIvero Luna" email="riveroluna@protonmail.com" automatic="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/i18n/en/nova_music.ftl" beforeDir="false" afterPath="$PROJECT_DIR$/i18n/en/nova_music.ftl" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/home.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/home.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/albums.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/albums.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/playlists.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/playlists.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -364,7 +363,8 @@
       <workItem from="1754429245786" duration="5581000" />
       <workItem from="1754504020923" duration="598000" />
       <workItem from="1754504806768" duration="8733000" />
-      <workItem from="1754529603203" duration="6402000" />
+      <workItem from="1754529603203" duration="7752000" />
+      <workItem from="1754593504626" duration="3593000" />
     </task>
     <task id="LOCAL-00001" summary="Initial">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,14 +17,10 @@
     <list default="true" id="152ba708-cd46-4fc3-ab0c-616e9212beb1" name="Changes" comment="Settings menu is mostly done, added progress bar for file scanning (a file is considered scanned only after it is checled for metadata currently which is only done after initially gathering a list of all the files, probably super inefficient and it looks like nothing is progressing to the user until initial scan is done)&#10;&#10;Signed-off-by: Samuel Rivero Luna &lt;riveroluna@protonmail.com&gt;">
       <changelist_data name="Samuel RIvero Luna" email="riveroluna@protonmail.com" automatic="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/i18n/en/nova_music.ftl" beforeDir="false" afterPath="$PROJECT_DIR$/i18n/en/nova_music.ftl" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/i18n/es/nova_music.ftl" beforeDir="false" afterPath="$PROJECT_DIR$/i18n/es/nova_music.ftl" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/albums.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/albums.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/playlists.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/playlists.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/settings.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/settings.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/tracks.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/tracks.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -367,7 +363,8 @@
       <workItem from="1754504806768" duration="8733000" />
       <workItem from="1754529603203" duration="7752000" />
       <workItem from="1754593504626" duration="8303000" />
-      <workItem from="1754601895949" duration="655000" />
+      <workItem from="1754601895949" duration="7558000" />
+      <workItem from="1754669975647" duration="12353000" />
     </task>
     <task id="LOCAL-00001" summary="Initial">
       <option name="closed" value="true" />
@@ -449,6 +446,16 @@
           <url>file://$PROJECT_DIR$/src/app/home.rs</url>
           <line>225</line>
           <option name="timeStamp" value="2" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
+          <url>file://$PROJECT_DIR$/src/app.rs</url>
+          <line>1428</line>
+          <option name="timeStamp" value="3" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
+          <url>file://$PROJECT_DIR$/src/app.rs</url>
+          <line>1510</line>
+          <option name="timeStamp" value="4" />
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,9 +17,11 @@
     <list default="true" id="152ba708-cd46-4fc3-ab0c-616e9212beb1" name="Changes" comment="Settings menu is mostly done, added progress bar for file scanning (a file is considered scanned only after it is checled for metadata currently which is only done after initially gathering a list of all the files, probably super inefficient and it looks like nothing is progressing to the user until initial scan is done)&#10;&#10;Signed-off-by: Samuel Rivero Luna &lt;riveroluna@protonmail.com&gt;">
       <changelist_data name="Samuel RIvero Luna" email="riveroluna@protonmail.com" automatic="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Cargo.lock" beforeDir="false" afterPath="$PROJECT_DIR$/Cargo.lock" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/albums.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/albums.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/home.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/home.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/playlists.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/playlists.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/settings.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/settings.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/tracks.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/tracks.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -355,6 +357,8 @@
       <workItem from="1754271491412" duration="4813000" />
       <workItem from="1754334259633" duration="13058000" />
       <workItem from="1754354957816" duration="6952000" />
+      <workItem from="1754420148016" duration="5961000" />
+      <workItem from="1754426452789" duration="1726000" />
     </task>
     <task id="LOCAL-00001" summary="Initial">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,9 +17,14 @@
     <list default="true" id="152ba708-cd46-4fc3-ab0c-616e9212beb1" name="Changes" comment="Settings menu is mostly done, added progress bar for file scanning (a file is considered scanned only after it is checled for metadata currently which is only done after initially gathering a list of all the files, probably super inefficient and it looks like nothing is progressing to the user until initial scan is done)&#10;&#10;Signed-off-by: Samuel Rivero Luna &lt;riveroluna@protonmail.com&gt;">
       <changelist_data name="Samuel RIvero Luna" email="riveroluna@protonmail.com" automatic="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/i18n/en/nova_music.ftl" beforeDir="false" afterPath="$PROJECT_DIR$/i18n/en/nova_music.ftl" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/i18n/es/nova_music.ftl" beforeDir="false" afterPath="$PROJECT_DIR$/i18n/es/nova_music.ftl" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/albums.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/albums.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/playlists.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/playlists.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/settings.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/settings.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/tracks.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/tracks.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -81,7 +86,7 @@
     &quot;RunOnceActivity.rust.reset.selective.auto.import&quot;: &quot;true&quot;,
     &quot;git-widget-placeholder&quot;: &quot;testing&quot;,
     &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/home/srl/Programming/tasks&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/home/srl/Programming/nova-music&quot;,
     &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
     &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
     &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
@@ -90,7 +95,7 @@
     &quot;org.rust.cargo.project.model.PROJECT_DISCOVERY&quot;: &quot;true&quot;,
     &quot;org.rust.cargo.project.model.impl.CargoExternalSystemProjectAware.subscribe.first.balloon&quot;: &quot;&quot;,
     &quot;org.rust.first.attach.projects&quot;: &quot;true&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;language.rust&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;language.rust.cargo.check&quot;,
     &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
 }</component>
@@ -99,9 +104,6 @@
       <recent name="$PROJECT_DIR$/src" />
       <recent name="$PROJECT_DIR$/src/app" />
     </key>
-  </component>
-  <component name="RsExternalLinterProjectSettings">
-    <option name="tool" value="Clippy" />
   </component>
   <component name="RunAnythingCache">
     <option name="myCommands">
@@ -364,7 +366,8 @@
       <workItem from="1754504020923" duration="598000" />
       <workItem from="1754504806768" duration="8733000" />
       <workItem from="1754529603203" duration="7752000" />
-      <workItem from="1754593504626" duration="3593000" />
+      <workItem from="1754593504626" duration="8303000" />
+      <workItem from="1754601895949" duration="655000" />
     </task>
     <task id="LOCAL-00001" summary="Initial">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,12 +17,8 @@
     <list default="true" id="152ba708-cd46-4fc3-ab0c-616e9212beb1" name="Changes" comment="Settings menu is mostly done, added progress bar for file scanning (a file is considered scanned only after it is checled for metadata currently which is only done after initially gathering a list of all the files, probably super inefficient and it looks like nothing is progressing to the user until initial scan is done)&#10;&#10;Signed-off-by: Samuel Rivero Luna &lt;riveroluna@protonmail.com&gt;">
       <changelist_data name="Samuel RIvero Luna" email="riveroluna@protonmail.com" automatic="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/justfile" beforeDir="false" afterPath="$PROJECT_DIR$/justfile" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/app.desktop" beforeDir="false" afterPath="$PROJECT_DIR$/resources/app.desktop" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/app.metainfo.xml" beforeDir="false" afterPath="$PROJECT_DIR$/resources/app.metainfo.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/playlists.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/playlists.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/config.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/config.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/scan.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/scan.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/database.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/database.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -356,7 +352,8 @@
       <workItem from="1754071927921" duration="2882000" />
       <workItem from="1754075006602" duration="88000" />
       <workItem from="1754075348193" duration="1843000" />
-      <workItem from="1754271491412" duration="4512000" />
+      <workItem from="1754271491412" duration="4813000" />
+      <workItem from="1754334259633" duration="11146000" />
     </task>
     <task id="LOCAL-00001" summary="Initial">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,8 +17,13 @@
     <list default="true" id="152ba708-cd46-4fc3-ab0c-616e9212beb1" name="Changes" comment="Settings menu is mostly done, added progress bar for file scanning (a file is considered scanned only after it is checled for metadata currently which is only done after initially gathering a list of all the files, probably super inefficient and it looks like nothing is progressing to the user until initial scan is done)&#10;&#10;Signed-off-by: Samuel Rivero Luna &lt;riveroluna@protonmail.com&gt;">
       <changelist_data name="Samuel RIvero Luna" email="riveroluna@protonmail.com" automatic="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/justfile" beforeDir="false" afterPath="$PROJECT_DIR$/justfile" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/app.desktop" beforeDir="false" afterPath="$PROJECT_DIR$/resources/app.desktop" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/app.metainfo.xml" beforeDir="false" afterPath="$PROJECT_DIR$/resources/app.metainfo.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/playlists.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/playlists.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/config.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/config.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/database.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/database.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -61,38 +66,38 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "Cargo.Build `Run`.executor": "Run",
-    "Cargo.Just.executor": "Run",
-    "Cargo.Run cosmic-music.executor": "Run",
-    "Cargo.Run.executor": "Run",
-    "Cargo.fetch.executor": "Run",
-    "Cargo.generate-lockfile.executor": "Run",
-    "Cargo.update.executor": "Run",
-    "Just.Run.executor": "Run",
-    "Just.Unnamed.executor": "Run",
-    "Just.build-release.executor": "Run",
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "RunOnceActivity.rust.reset.selective.auto.import": "true",
-    "git-widget-placeholder": "main",
-    "junie.onboarding.icon.badge.shown": "true",
-    "last_opened_file_path": "/home/srl/.local/share/dev.riveroluna.novamusic/nova_music.db",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "org.rust.cargo.project.model.PROJECT_DISCOVERY": "true",
-    "org.rust.cargo.project.model.impl.CargoExternalSystemProjectAware.subscribe.first.balloon": "",
-    "org.rust.first.attach.projects": "true",
-    "settings.editor.selected.configurable": "preferences.pluginManager",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;Cargo.Build `Run`.executor&quot;: &quot;Run&quot;,
+    &quot;Cargo.Just.executor&quot;: &quot;Run&quot;,
+    &quot;Cargo.Run cosmic-music.executor&quot;: &quot;Run&quot;,
+    &quot;Cargo.Run.executor&quot;: &quot;Run&quot;,
+    &quot;Cargo.fetch.executor&quot;: &quot;Run&quot;,
+    &quot;Cargo.generate-lockfile.executor&quot;: &quot;Run&quot;,
+    &quot;Cargo.update.executor&quot;: &quot;Run&quot;,
+    &quot;Just.Run.executor&quot;: &quot;Run&quot;,
+    &quot;Just.Unnamed.executor&quot;: &quot;Run&quot;,
+    &quot;Just.build-release.executor&quot;: &quot;Run&quot;,
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.rust.reset.selective.auto.import&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;testing&quot;,
+    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/home/srl/.local/share/dev.riveroluna.novamusic/nova_music.db&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;org.rust.cargo.project.model.PROJECT_DISCOVERY&quot;: &quot;true&quot;,
+    &quot;org.rust.cargo.project.model.impl.CargoExternalSystemProjectAware.subscribe.first.balloon&quot;: &quot;&quot;,
+    &quot;org.rust.first.attach.projects&quot;: &quot;true&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/src" />
@@ -347,7 +352,11 @@
       <workItem from="1753831613265" duration="916000" />
       <workItem from="1753899744864" duration="17936000" />
       <workItem from="1753925038290" duration="5440000" />
-      <workItem from="1753931388615" duration="6797000" />
+      <workItem from="1753931388615" duration="13634000" />
+      <workItem from="1754071927921" duration="2882000" />
+      <workItem from="1754075006602" duration="88000" />
+      <workItem from="1754075348193" duration="1843000" />
+      <workItem from="1754271491412" duration="4512000" />
     </task>
     <task id="LOCAL-00001" summary="Initial">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,9 +17,9 @@
     <list default="true" id="152ba708-cd46-4fc3-ab0c-616e9212beb1" name="Changes" comment="Settings menu is mostly done, added progress bar for file scanning (a file is considered scanned only after it is checled for metadata currently which is only done after initially gathering a list of all the files, probably super inefficient and it looks like nothing is progressing to the user until initial scan is done)&#10;&#10;Signed-off-by: Samuel Rivero Luna &lt;riveroluna@protonmail.com&gt;">
       <changelist_data name="Samuel RIvero Luna" email="riveroluna@protonmail.com" automatic="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Cargo.lock" beforeDir="false" afterPath="$PROJECT_DIR$/Cargo.lock" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/scan.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/scan.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/database.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/database.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/albums.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/albums.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -81,7 +81,7 @@
     &quot;RunOnceActivity.rust.reset.selective.auto.import&quot;: &quot;true&quot;,
     &quot;git-widget-placeholder&quot;: &quot;testing&quot;,
     &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/home/srl/.local/share/dev.riveroluna.novamusic/nova_music.db&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/home/srl/Programming/cosmic-store&quot;,
     &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
     &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
     &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
@@ -353,7 +353,8 @@
       <workItem from="1754075006602" duration="88000" />
       <workItem from="1754075348193" duration="1843000" />
       <workItem from="1754271491412" duration="4813000" />
-      <workItem from="1754334259633" duration="11146000" />
+      <workItem from="1754334259633" duration="13058000" />
+      <workItem from="1754354957816" duration="6952000" />
     </task>
     <task id="LOCAL-00001" summary="Initial">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -17,11 +17,10 @@
     <list default="true" id="152ba708-cd46-4fc3-ab0c-616e9212beb1" name="Changes" comment="Settings menu is mostly done, added progress bar for file scanning (a file is considered scanned only after it is checled for metadata currently which is only done after initially gathering a list of all the files, probably super inefficient and it looks like nothing is progressing to the user until initial scan is done)&#10;&#10;Signed-off-by: Samuel Rivero Luna &lt;riveroluna@protonmail.com&gt;">
       <changelist_data name="Samuel RIvero Luna" email="riveroluna@protonmail.com" automatic="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/i18n/en/nova_music.ftl" beforeDir="false" afterPath="$PROJECT_DIR$/i18n/en/nova_music.ftl" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/home.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/home.rs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/playlists.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/playlists.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/settings.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/settings.rs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/tracks.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/tracks.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -83,7 +82,7 @@
     &quot;RunOnceActivity.rust.reset.selective.auto.import&quot;: &quot;true&quot;,
     &quot;git-widget-placeholder&quot;: &quot;testing&quot;,
     &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/home/srl/Programming/cosmic-store&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/home/srl/Programming/tasks&quot;,
     &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
     &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
     &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
@@ -92,7 +91,7 @@
     &quot;org.rust.cargo.project.model.PROJECT_DISCOVERY&quot;: &quot;true&quot;,
     &quot;org.rust.cargo.project.model.impl.CargoExternalSystemProjectAware.subscribe.first.balloon&quot;: &quot;&quot;,
     &quot;org.rust.first.attach.projects&quot;: &quot;true&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;language.rust&quot;,
     &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
 }</component>
@@ -101,6 +100,9 @@
       <recent name="$PROJECT_DIR$/src" />
       <recent name="$PROJECT_DIR$/src/app" />
     </key>
+  </component>
+  <component name="RsExternalLinterProjectSettings">
+    <option name="tool" value="Clippy" />
   </component>
   <component name="RunAnythingCache">
     <option name="myCommands">
@@ -358,7 +360,11 @@
       <workItem from="1754334259633" duration="13058000" />
       <workItem from="1754354957816" duration="6952000" />
       <workItem from="1754420148016" duration="5961000" />
-      <workItem from="1754426452789" duration="1726000" />
+      <workItem from="1754426452789" duration="2302000" />
+      <workItem from="1754429245786" duration="5581000" />
+      <workItem from="1754504020923" duration="598000" />
+      <workItem from="1754504806768" duration="8733000" />
+      <workItem from="1754529603203" duration="6402000" />
     </task>
     <task id="LOCAL-00001" summary="Initial">
       <option name="closed" value="true" />
@@ -438,7 +444,7 @@
       <breakpoints>
         <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
           <url>file://$PROJECT_DIR$/src/app/home.rs</url>
-          <line>224</line>
+          <line>225</line>
           <option name="timeStamp" value="2" />
         </line-breakpoint>
       </breakpoints>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f4f6fbdc5ee39f2ede9f5f3ec79477271a6d6a2baff22310d51736bda6cea"
+checksum = "e074464580a518d16a7126262fffaaa47af89d4099d4cb403f8ed938ba12ee7d"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -274,7 +274,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.1",
+ "rand 0.9.2",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -283,7 +283,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus 5.8.0",
+ "zbus 5.9.0",
 ]
 
 [[package]]
@@ -302,7 +302,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -329,7 +329,7 @@ dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.3.0",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
  "pin-project-lite",
  "slab",
 ]
@@ -356,21 +356,20 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
- "async-lock 3.4.0",
+ "async-lock 3.4.1",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
  "parking",
- "polling 3.8.0",
+ "polling 3.10.0",
  "rustix 1.0.8",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -384,11 +383,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -412,21 +411,20 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
  "async-channel",
- "async-io 2.4.1",
- "async-lock 3.4.0",
+ "async-io 2.5.0",
+ "async-lock 3.4.1",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.0",
- "futures-lite 2.6.0",
+ "event-listener 5.4.1",
+ "futures-lite 2.6.1",
  "rustix 1.0.8",
- "tracing",
 ]
 
 [[package]]
@@ -442,12 +440,12 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
 dependencies = [
- "async-io 2.4.1",
- "async-lock 3.4.0",
+ "async-io 2.5.0",
+ "async-lock 3.4.1",
  "atomic-waker",
  "cfg-if",
  "futures-core",
@@ -455,7 +453,7 @@ dependencies = [
  "rustix 1.0.8",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -659,7 +657,7 @@ dependencies = [
  "async-channel",
  "async-task",
  "futures-io",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
  "piper",
 ]
 
@@ -686,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -721,7 +719,7 @@ checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
  "bitflags 2.9.1",
  "log",
- "polling 3.8.0",
+ "polling 3.10.0",
  "rustix 0.38.44",
  "slab",
  "thiserror 1.0.69",
@@ -741,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
  "libc",
@@ -790,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
@@ -1009,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1025,13 +1023,13 @@ dependencies = [
  "tokio",
  "tracing",
  "xdg",
- "zbus 5.8.0",
+ "zbus 5.9.0",
 ]
 
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -1069,13 +1067,13 @@ name = "cosmic-settings-daemon"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930a3536ab714b843c851fa8ca"
 dependencies = [
- "zbus 5.8.0",
+ "zbus 5.9.0",
 ]
 
 [[package]]
 name = "cosmic-text"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#85b07b4c8c6b825aca984648fed7ee49b6591d97"
+source = "git+https://github.com/pop-os/cosmic-text.git#de355a1fd9855e78273d4b7f2b5716eaaa38484f"
 dependencies = [
  "bitflags 2.9.1",
  "fontdb 0.23.0",
@@ -1097,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1373,7 +1371,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
+ "redox_users 0.5.2",
  "windows-sys 0.60.2",
 ]
 
@@ -1588,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1603,7 +1601,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1908,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand 2.3.0",
  "futures-core",
@@ -2304,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2322,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2331,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -2356,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "futures",
  "iced_core",
@@ -2382,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -2404,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2416,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -2432,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2448,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.9.1",
@@ -2479,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -2499,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -2748,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -2858,11 +2856,11 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "known-folders"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d9a1740cc8b46e259a0eb787d79d855e79ff10b9855a5eba58868d5da7927c"
+checksum = "c644f4623d1c55eb60a9dac35e0858a59f982fb87db6ce34c872372b0a5b728f"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2897,11 +2895,12 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1077d333efea6170d9ccb96d3c3026f300ca0773da4938cc4c811daa6df68b0c"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
+ "euclid",
  "smallvec",
 ]
 
@@ -2920,7 +2919,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#50367b96e3bb9a2a2a62a6c51cd71fc2858e61ed"
+source = "git+https://github.com/pop-os/libcosmic.git#b58d864e85b3b842132e9be1b6445ad21c1f0258"
 dependencies = [
  "apply",
  "ashpd",
@@ -2958,7 +2957,7 @@ dependencies = [
  "tracing",
  "unicode-segmentation",
  "url",
- "zbus 5.8.0",
+ "zbus 5.9.0",
 ]
 
 [[package]]
@@ -2968,7 +2967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2979,13 +2978,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.17",
 ]
 
 [[package]]
@@ -3030,9 +3029,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "locale_config"
@@ -3319,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.9.1",
  "fsevent-sys",
@@ -3854,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser 0.25.1",
 ]
@@ -3935,7 +3934,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4086,17 +4085,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.0.8",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4241,9 +4239,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4295,9 +4293,9 @@ checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
 
 [[package]]
 name = "rangemap"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
+checksum = "f93e7e49bb0bf967717f7bd674458b3d6b0c5f48ec7e3038166026a69fc22223"
 
 [[package]]
 name = "raw-window-handle"
@@ -4355,9 +4353,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4375,9 +4373,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -4549,9 +4547,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -4705,9 +4703,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4757,9 +4755,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -4876,12 +4874,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4952,14 +4950,13 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.104",
 ]
 
@@ -4975,7 +4972,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo 0.11.2",
+ "kurbo 0.11.3",
  "siphasher",
 ]
 
@@ -5399,9 +5396,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5412,10 +5409,10 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5663,7 +5660,7 @@ dependencies = [
  "flate2",
  "fontdb 0.18.0",
  "imagesize",
- "kurbo 0.11.2",
+ "kurbo 0.11.3",
  "log",
  "pico-args",
  "roxmltree",
@@ -5828,13 +5825,13 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe770181423e5fc79d3e2a7f4410b7799d5aab1de4372853de3c6aa13ca24121"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -5842,12 +5839,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.9.1",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -5865,20 +5862,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65317158dec28d00416cb16705934070aef4f8393353d41126c54264ae0f182"
+checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
 dependencies = [
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.8"
+version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
  "bitflags 2.9.1",
  "wayland-backend",
@@ -5889,9 +5886,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd38cdad69b56ace413c6bcc1fbf5acc5e2ef4af9d5f8f1f9570c0c83eae175"
+checksum = "a07a14257c077ab3279987c4f8bb987851bf57081b93710381daea94f2c2c032"
 dependencies = [
  "bitflags 2.9.1",
  "wayland-backend",
@@ -5902,9 +5899,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb6cdc73399c0e06504c437fe3cf886f25568dd5454473d565085b36d6a8bbf"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
 dependencies = [
  "bitflags 2.9.1",
  "wayland-backend",
@@ -5916,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -5927,22 +5924,22 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.9"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485dfb8ccf0daa0d34625d34e6ac15f99e550a7999b6fd88a0835ccd37655785"
+checksum = "fcbd4f3aba6c9fba70445ad2a484c0ef0356c1a9459b1e8e435bedc1971a6222"
 dependencies = [
  "bitflags 2.9.1",
  "downcast-rs",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "wayland-backend",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
 dependencies = [
  "dlib",
  "log",
@@ -6307,7 +6304,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -6358,10 +6355,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -6809,23 +6807,23 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.8.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f45e98bc7e6f0988276012797855613cd8269e23b5be62cc4e5d28b7e515d"
+checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
 dependencies = [
  "async-broadcast 0.7.2",
  "async-executor",
- "async-io 2.4.1",
- "async-lock 3.4.0",
- "async-process 2.3.1",
+ "async-io 2.5.0",
+ "async-lock 3.4.1",
+ "async-process 2.4.0",
  "async-recursion",
  "async-task",
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "futures-core",
- "futures-lite 2.6.0",
+ "futures-lite 2.6.1",
  "hex",
  "nix 0.30.1",
  "ordered-stream",
@@ -6836,7 +6834,7 @@ dependencies = [
  "uds_windows",
  "windows-sys 0.59.0",
  "winnow 0.7.12",
- "zbus_macros 5.8.0",
+ "zbus_macros 5.9.0",
  "zbus_names 4.2.0",
  "zvariant 5.6.0",
 ]
@@ -6857,9 +6855,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.8.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c8e4e14dcdd9d97a98b189cd1220f30e8394ad271e8c987da84f73693862c2"
+checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -6953,9 +6951,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "bdbb9122ea75b11bf96e7492afb723e8a7fbe12c67417aa95e7e3d18144d37cd"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6981,9 +6979,9 @@ checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9e525af0a6a658e031e95f14b7f889976b74a11ba0eca5a5fc9ac8a1c43a6a"
+checksum = "fc1f7e205ce79eb2da3cd71c5f55f3589785cb7c79f6a03d1c8d1491bda5d089"
 dependencies = [
  "zune-core",
 ]

--- a/README.md
+++ b/README.md
@@ -3,12 +3,25 @@
 - An album focused music player written in the libcosmic toolkit
 
 TODO
-- ~~[ ! ] Replace current playlist implementation with m3u~~
-- Playlist updates: Allow M3U import from inside app, allow custom cover art, delete playlists from inside app
-- Localization update
+~~-[ ! ] Replace current playlist implementation with m3u~~
+~~- Playlist updates: Allow M3U import from inside app, allow custom cover art, delete playlists from inside app~~
+~~- Localization update~~
+- Artist View
+- Shuffle
+- Gapless Playback
 - Crossfade support
+- Basic Keybinds 
+- Flatpak release!
+
+Updates
+- Playlists now stored in local data directory as utf8 m3u files.
+- Creating a playlist allows you to choose and icon to display. (Filepath to icon is saved in the M3U)
+- When scanning the music directory, Nova Music will detect m3u files and make a personal copy in the local data directory.
+- The user is now notified in the case of most errors rather than doing nothing or crashing.
+- All the text in the app is now utilizing localization with i18n so translations are now possible.
+
 ## Installation
-NOTE: Playlist implementation will be replaced soon dont rely on it. Other than that the software should be usable. Please feel free to request features and report bugs. I'll do my best to stay on top of them inbetween school work.
+This software is still in development! Major changes may be made in the future and it may still be buggy.
 
 A [justfile](./justfile) is included by default for the [casey/just][just] command runner.
 

--- a/i18n/en/nova_music.ftl
+++ b/i18n/en/nova_music.ftl
@@ -35,6 +35,8 @@ DialogPlaylistPrimary = Create
 DialogPlaylistDelete = Delete playlist?
 DialogPlaylistDeleteClarify = Delete {$path}?
 DialogPlaylistDeleteConfirm = Delete playlist
+# PLaylist Edit Dialog
+DialogPlaylistEdit = Edit playlist
 
 # Inputs (Used Multiple Times)
 PlaylistInputPlaceholder = Enter playlist name

--- a/i18n/en/nova_music.ftl
+++ b/i18n/en/nova_music.ftl
@@ -1,18 +1,45 @@
 app-title = Nova Music
 
-# Pages
+# Context Pages
 view = View
 about = About
+git-description = Git commit {$hash} on {$date}
 settings = Settings
 
-scandir = Scan Directory
-
+# Pages
 home = Home
 tracks = Tracks
 artists = Artists
 albums = Albums
 playlists = Playlists
-
 album = Album
-welcome = Welcome to COSMIC! ✨
-git-description = Git commit {$hash} on {$date}
+
+scandir = Scan Directory
+
+# First Time Setup
+currentdir = Current Directory
+folderselect = Select Folder
+firsttimetitle = Welcome to Nova Music!
+firsttimebody = Please select a folder for scanning to get Nova Music ready.
+firsttimeprimary = Scan folder & continue
+
+# Playlist Creation Dialog
+DialogPlaylistTitle = Create A New Playlist
+DialogPlaylistChosenName = Playlist Title:
+DialogPlaylistPrimary = Create
+# Playlist Deletion Dialog
+DialogPlaylistDelete = Delete Playlist?
+DialogPlaylistDeleteClarify = Delete {$path}?
+DialogPlaylistDeleteConfirm = Delete Playlist
+
+# Inputs
+PlaylistInputPlaceholder = Enter Playlist Name
+
+# Common Buttons
+Cancel= Cancel
+
+# Home Page
+Queue = Queue
+CreatePlaylist = Create Playlist
+ClearAll = Clear ALl
+NowPlaying = Now Playing

--- a/i18n/en/nova_music.ftl
+++ b/i18n/en/nova_music.ftl
@@ -12,34 +12,68 @@ tracks = Tracks
 artists = Artists
 albums = Albums
 playlists = Playlists
-album = Album
+Loading = Loading...
 
-scandir = Scan Directory
+# Common Terms
+album = Album
+title = Title
+artist = Artist
+
+scandir = Scan directory
 
 # First Time Setup
-currentdir = Current Directory
-folderselect = Select Folder
+currentdir = Current directory
 firsttimetitle = Welcome to Nova Music!
 firsttimebody = Please select a folder for scanning to get Nova Music ready.
 firsttimeprimary = Scan folder & continue
 
 # Playlist Creation Dialog
-DialogPlaylistTitle = Create A New Playlist
-DialogPlaylistChosenName = Playlist Title:
+DialogPlaylistTitle = Create a new playlist
+DialogPlaylistChosenName = Playlist title:
 DialogPlaylistPrimary = Create
 # Playlist Deletion Dialog
-DialogPlaylistDelete = Delete Playlist?
+DialogPlaylistDelete = Delete playlist?
 DialogPlaylistDeleteClarify = Delete {$path}?
-DialogPlaylistDeleteConfirm = Delete Playlist
+DialogPlaylistDeleteConfirm = Delete playlist
 
-# Inputs
-PlaylistInputPlaceholder = Enter Playlist Name
+# Inputs (Used Multiple Times)
+PlaylistInputPlaceholder = Enter playlist name
 
 # Common Buttons
 Cancel= Cancel
+AddToQueue = Add To Queue
+folderselect = Select folder
 
 # Home Page
 Queue = Queue
 CreatePlaylist = Create Playlist
 ClearAll = Clear ALl
 NowPlaying = Now Playing
+
+# Album Page
+AlbumLibrary = Album Library
+AlbumInputPlaceholder = Enter album name
+AlbumDiscNumber = Disc {$number}
+AlbumAttribution = {$artist}
+
+#Track Page
+TrackLibrary = Track Library
+TrackInputPlaceholder = Enter track information
+SearchFilter = Search By
+SearchFilterSpecify = By {$filter}
+
+# Settings Page
+MusicDirectory = Music Directory
+CurrentScanResults = Current Scan Results
+FilesScanned = Files Scanned
+MusicScanning = Music Scanning
+FullRescan = Full Rescan
+Rescan = Rescan
+ScanProgress = Scan Progress
+UserInterface = User Interface
+GridItemSize = Grid Item Size
+MusicPlayer = Music Player
+AppVolume = App Volume {$volume}
+
+# Error
+SearchFailed = Search failed!

--- a/i18n/es/nova_music.ftl
+++ b/i18n/es/nova_music.ftl
@@ -35,6 +35,8 @@ DialogPlaylistPrimary = Crear
 DialogPlaylistDelete = Eliminar playlist?
 DialogPlaylistDeleteClarify = Eliminar {$path}?
 DialogPlaylistDeleteConfirm = Eliminar Playlist
+# PLaylist Edit Dialog
+DialogPlaylistEdit = Editar playlist
 
 # Inputs
 PlaylistInputPlaceholder = Título del Playlist

--- a/i18n/es/nova_music.ftl
+++ b/i18n/es/nova_music.ftl
@@ -1,0 +1,44 @@
+app-title = Nova Music
+
+# Context Pages
+view = Vista
+about = Acerca De Nova Music
+git-description = Git commit {$hash} on {$date}
+settings = Configuración
+
+# Pages
+home = Inicio
+tracks = Canciones
+artists = Artistas
+albums = Álbumes
+playlists = Playlists
+album = Álbum
+
+scandir = Escanear Directorio
+
+# First Time Setup
+currentdir = Directorio eligido
+folderselect = Elige una carpeta
+firsttimetitle = Bienvenido a Nova Music!
+firsttimebody = Por favor escoge alguna carpeta para escanear y preparar Nova Music
+firsttimeprimary = Escanea la carpeta y avanza
+
+# Playlist Creation Dialog
+DialogPlaylistTitle =  Nueva Playlist
+DialogPlaylistChosenName = Titulo de playlist:
+# Playlist Deletion Dialog
+DialogPlaylistDelete = Eliminar playlist?
+DialogPlaylistDeleteClarify = Elimnar {$path}?
+DialogPlaylistDeleteConfirm = Elimnar Playlist
+
+# Inputs
+PlaylistInputPlaceholder = Título del Playlist
+
+# Common Buttons
+Cancel= Cancelar
+
+# Home Page
+Queue = Fila
+CreatePlaylist = Crear Playlist
+ClearAll = Eliminar Fila
+NowPlaying = Reproduciendo Ahora:

--- a/i18n/es/nova_music.ftl
+++ b/i18n/es/nova_music.ftl
@@ -8,17 +8,21 @@ settings = Configuración
 
 # Pages
 home = Inicio
-tracks = Canciones
+tracks = Pistas
 artists = Artistas
 albums = Álbumes
 playlists = Playlists
+Loading = Cargando...
+
+# Common Terms
 album = Álbum
+title = Título
+artist = Artista
 
 scandir = Escanear Directorio
 
 # First Time Setup
 currentdir = Directorio eligido
-folderselect = Elige una carpeta
 firsttimetitle = Bienvenido a Nova Music!
 firsttimebody = Por favor escoge alguna carpeta para escanear y preparar Nova Music
 firsttimeprimary = Escanea la carpeta y avanza
@@ -26,19 +30,50 @@ firsttimeprimary = Escanea la carpeta y avanza
 # Playlist Creation Dialog
 DialogPlaylistTitle =  Nueva Playlist
 DialogPlaylistChosenName = Titulo de playlist:
+DialogPlaylistPrimary = Crear
 # Playlist Deletion Dialog
 DialogPlaylistDelete = Eliminar playlist?
-DialogPlaylistDeleteClarify = Elimnar {$path}?
-DialogPlaylistDeleteConfirm = Elimnar Playlist
+DialogPlaylistDeleteClarify = Eliminar {$path}?
+DialogPlaylistDeleteConfirm = Eliminar Playlist
 
 # Inputs
 PlaylistInputPlaceholder = Título del Playlist
 
 # Common Buttons
 Cancel= Cancelar
+AddToQueue = Agrega al fila
+folderselect = Elige una carpeta
 
 # Home Page
 Queue = Fila
 CreatePlaylist = Crear Playlist
 ClearAll = Eliminar Fila
 NowPlaying = Reproduciendo Ahora:
+
+# Album Page
+AlbumLibrary = Biblioteca de Álbumes
+AlbumInputPlaceholder = Título de álbum
+AlbumDiscNumber = Disco {$number}
+AlbumAttribution = {$artist}
+
+#Track Page
+TrackLibrary = Biblioteca de Pistas
+TrackInputPlaceholder = Informacíon sobre alguna pista
+SearchFilter = Busca por
+SearchFilterSpecify = Por {$filter}
+
+# Settings Page
+MusicDirectory = Directorio de Música
+CurrentScanResults = Resultados del escaneo
+FilesScanned = Archivos Escaneados
+MusicScanning = Música Escaneada
+FullRescan = Volver a escanear
+Rescan = Escanear
+ScanProgress = Scan Progress
+UserInterface = Interface de usuario
+GridItemSize = Tamaño de elementos
+MusicPlayer = Reproducidor de Música
+AppVolume = Volumen del applicacion {$volume}
+
+# Error
+SearchFailed = Error con la buscada!

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 name := 'nova-music'
-appid := 'dev.riveroluna.novamusic'
+appid := 'dev.riveroluna.NovaMusic'
 
 rootdir := ''
 prefix := '/usr'

--- a/resources/app.desktop
+++ b/resources/app.desktop
@@ -2,10 +2,10 @@
 Name=Nova Music
 Comment=A music player written in the libcosmic toolkit
 Type=Application
-Icon=dev.riveroluna.novamusic
+Icon=dev.riveroluna.NovaMusic
 Exec=nova-music %F
 Terminal=false
 StartupNotify=true
-Categories=MUSIC
-Keywords=MUSIC
+Categories=Audio;AudioVideo
+Keywords=Music
 MimeType=

--- a/resources/app.metainfo.xml
+++ b/resources/app.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>dev.riveroluna.novamusic</id>
+  <id>dev.riveroluna.NovaMusic</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
   <name>Nova Music</name>
@@ -9,9 +9,9 @@
     https://github.com/SRiverol/NovaMusic.git/raw/main/resources/icons/hicolor/scalable/apps/icon.svg
   </icon>
   <url type="vcs-browser">https://github.com/SRiverol/CosmicMusic.git</url>
-  <launchable type="desktop-id">dev.riveroluna.novamusic.desktop</launchable>
+  <launchable type="desktop-id">dev.riveroluna.NovaMusic.desktop</launchable>
   <provides>
-    <id>dev.riveroluna.novamusic</id>
+    <id>dev.riveroluna.NovaMusic</id>
     <binaries>
       <binary>nova-music</binary>
     </binaries>

--- a/src/app.rs
+++ b/src/app.rs
@@ -256,7 +256,7 @@ impl cosmic::Application for AppModel {
     type Message = Message;
 
     /// Unique identifier in RDNN (reverse domain name notation) format.
-    const APP_ID: &'static str = "dev.riveroluna.novamusic";
+    const APP_ID: &'static str = "dev.riveroluna.NovaMusic";
 
     fn core(&self) -> &cosmic::Core {
         &self.core

--- a/src/app.rs
+++ b/src/app.rs
@@ -945,7 +945,10 @@ impl cosmic::Application for AppModel {
                 {
                     Ok(a) => a,
                     Err(err) => {
-                        panic!("{}", err)
+                        return self
+                            .toasts
+                            .push(cosmic::widget::toaster::Toast::new(fl!("SearchFailed")))
+                            .map(cosmic::Action::App);
                     }
                 };
 
@@ -1805,6 +1808,7 @@ from track
                     let decoder = rodio::Decoder::builder()
                         .with_byte_len(file.metadata().unwrap().len())
                         .with_data(file)
+                        .with_gapless(true)
                         .with_seekable(true)
                         .build()
                         .expect("Failed to build decoder");
@@ -2027,6 +2031,7 @@ from track
                 let decoder = rodio::Decoder::builder()
                     .with_byte_len(file.metadata().unwrap().len())
                     .with_data(file)
+                    .with_gapless(true)
                     .with_seekable(true)
                     .build()
                     .expect("Failed to build decoder");

--- a/src/app/albums.rs
+++ b/src/app/albums.rs
@@ -134,7 +134,7 @@ impl AlbumPage {
                                         cosmic::widget::column::with_children(vec![
                                             if let Some(cover_art) = &album.cover_art {
                                                 cosmic::widget::container::Container::new(
-                                                    cosmic::widget::image(cover_art),
+                                                    cosmic::widget::image(cover_art).content_fit(ContentFit::Fill),
                                                 )
                                                 .height((model.config.grid_item_size * 32) as f32)
                                                 .width((model.config.grid_item_size * 32) as f32)
@@ -261,7 +261,7 @@ impl AlbumPage {
                                         .into()
                                 }
                                 Some(handle) => cosmic::widget::image(handle)
-                                    .content_fit(ContentFit::Contain)
+                                    .content_fit(ContentFit::Fill)
                                     .height(128.0)
                                     .width(128.0)
                                     .into(),

--- a/src/app/albums.rs
+++ b/src/app/albums.rs
@@ -10,12 +10,15 @@ use cosmic::{iced, widget, Application, Element, Theme};
 use futures_util::{SinkExt, StreamExt};
 use rusqlite::fallible_iterator::FallibleIterator;
 use std::sync::Arc;
+use cosmic::iced_widget::scrollable::Viewport;
 
 #[derive(Clone, Debug)]
 pub struct AlbumPage {
     pub albums: Arc<Vec<Album>>,
     pub page_state: AlbumPageState,
     pub has_fully_loaded: bool,
+    pub viewport: Option<Viewport>,
+    pub scrollbar_id: cosmic::iced_core::widget::Id,
 }
 
 #[derive(Clone, Debug)]
@@ -35,11 +38,14 @@ impl AlbumPage {
             albums: Arc::from(album_list),
             page_state: AlbumPageState::Loading,
             has_fully_loaded: false,
+            viewport: None,
+            scrollbar_id: cosmic::iced_core::widget::Id::unique()
         }
     }
 
     pub fn load_page<'a>(&'a self, model: &'a AppModel) -> Element<'a, Message> {
         let page_margin = cosmic::theme::spacing().space_m;
+
         match &self.page_state {
             AlbumPageState::Loading | AlbumPageState::Loaded => {
                 if self.albums.is_empty() {
@@ -218,6 +224,8 @@ impl AlbumPage {
                                 )
                                 .align_x(Alignment::Center),
                             )
+                                .id(self.scrollbar_id.clone())
+                                .on_scroll(|view| Message::ScrollView(view))
                             .into()
                         }))
                         .height(Length::Fill)

--- a/src/app/albums.rs
+++ b/src/app/albums.rs
@@ -11,6 +11,7 @@ use futures_util::{SinkExt, StreamExt};
 use rusqlite::fallible_iterator::FallibleIterator;
 use std::sync::Arc;
 use cosmic::iced_widget::scrollable::Viewport;
+use crate::fl;
 
 #[derive(Clone, Debug)]
 pub struct AlbumPage {
@@ -50,7 +51,7 @@ impl AlbumPage {
             AlbumPageState::Loading | AlbumPageState::Loaded => {
                 if self.albums.is_empty() {
                     return if let AlbumPageState::Loading = self.page_state {
-                        cosmic::widget::container(cosmic::widget::text::title3("Loading..."))
+                        cosmic::widget::container(cosmic::widget::text::title3(fl!("Loading")))
                             .align_x(Alignment::Center)
                             .align_y(Alignment::Center)
                             .width(Length::Fill)
@@ -63,14 +64,14 @@ impl AlbumPage {
                                 vec![
 
                                     cosmic::widget::row::with_children(vec![
-                                        cosmic::widget::text::title2("Album Library")
+                                        cosmic::widget::text::title2(fl!("AlbumLibrary"))
                                             .width(Length::FillPortion(2))
                                             .into(),
                                         cosmic::widget::horizontal_space()
                                             .width(Length::Shrink)
                                             .into(),
                                         cosmic::widget::search_input(
-                                            "Enter Album Name",
+                                            fl!("AlbumInputPlaceholder"),
                                             model.search_field.as_str(),
                                         )
                                             .on_input(|input| Message::UpdateSearch(input))
@@ -103,14 +104,14 @@ impl AlbumPage {
                 cosmic::widget::container(
                     cosmic::widget::column::with_children(vec![
                         cosmic::widget::row::with_children(vec![
-                            cosmic::widget::text::title2("Album Library")
+                            cosmic::widget::text::title2(fl!("AlbumLibrary"))
                                 .width(Length::FillPortion(2))
                                 .into(),
                             cosmic::widget::horizontal_space()
                                 .width(Length::Shrink)
                                 .into(),
                             cosmic::widget::search_input(
-                                "Enter Album Name",
+                                fl!("AlbumInputPlaceholder"),
                                 model.search_field.as_str(),
                             )
                             .on_input(|input| Message::UpdateSearch(input))
@@ -245,7 +246,7 @@ impl AlbumPage {
                         cosmic::widget::button::custom(
                             cosmic::widget::row::with_children(vec![
                                 cosmic::widget::icon::from_name("go-previous-symbolic").into(),
-                                cosmic::widget::text::text("Albums").into(),
+                                cosmic::widget::text::text(fl!("albums")).into(),
                             ])
                             .align_y(Alignment::Center),
                         )
@@ -269,12 +270,11 @@ impl AlbumPage {
                             cosmic::widget::Column::with_children([
                                 // Album Title and Author Column
                                 cosmic::widget::text::title2(albumpage.album.name.clone()).into(),
-                                cosmic::widget::text::title4(format!(
-                                    "By {}",
-                                    albumpage.album.artist.as_str()
-                                ))
+                                cosmic::widget::text::title4(
+                                    fl!("AlbumAttribution", artist = albumpage.album.artist.clone())
+                                )
                                 .into(),
-                                cosmic::widget::button::text("Add to queue")
+                                cosmic::widget::button::text(fl!("AddToQueue"))
                                     .leading_icon(cosmic::widget::icon::from_name(
                                         "media-playback-start-symbolic",
                                     ))
@@ -312,14 +312,14 @@ impl AlbumPage {
             AlbumPageState::Search(search_results) => {
                 cosmic::widget::container(cosmic::widget::column::with_children(vec![
                     cosmic::widget::row::with_children(vec![
-                        cosmic::widget::text::title2("Album Library")
+                        cosmic::widget::text::title2(fl!("AlbumLibrary"))
                             .width(Length::FillPortion(2))
                             .into(),
                         cosmic::widget::horizontal_space()
                             .width(Length::Shrink)
                             .into(),
                         cosmic::widget::search_input(
-                            "Enter Album Name",
+                            fl!("AlbumInputPlaceholder"),
                             model.search_field.as_str(),
                         )
                         .on_input(|input| Message::UpdateSearch(input))
@@ -531,7 +531,7 @@ fn tracks_listify<'a>(tracks: &Vec<Track>, num_of_discs: u32) -> Element<'a, Mes
         }
         disc_lists.push(
             cosmic::widget::container(cosmic::widget::column::with_children(vec![
-                cosmic::widget::text::heading(format!("Disc {}", disc_num)).into(),
+                cosmic::widget::text::heading(fl!("AlbumDiscNumber", number = disc_num)).into(),
                 list.unwrap().into_element(),
             ]))
             .into(),

--- a/src/app/home.rs
+++ b/src/app/home.rs
@@ -27,7 +27,7 @@ use humantime::format_duration;
 pub(crate) struct HomePage;
 
 impl HomePage {
-    pub fn load_page(&self, model: &AppModel) -> Element<'static, app::Message> {
+    pub fn load_page<'a>(&self, model: &'a AppModel) -> Element<'a, app::Message> {
         // Time ELapsed
         let mut time_elapsed = format_time(model.song_progress);
 

--- a/src/app/home.rs
+++ b/src/app/home.rs
@@ -1,3 +1,4 @@
+use crate::fl;
 use std::borrow::Cow;
 use crate::app;
 use crate::app::albums::Album;
@@ -185,13 +186,13 @@ impl HomePage {
                     cosmic::widget::container(cosmic::widget::column::with_children(vec![
                         cosmic::widget::container(
                             cosmic::widget::row::with_children(vec![
-                                cosmic::widget::text::heading("Queue: ").center().into(),
+                                cosmic::widget::text::heading(fl!("Queue")).center().into(),
                                 cosmic::widget::horizontal_space().into(),
-                                cosmic::widget::button::text("Create Playlist")
+                                cosmic::widget::button::text(fl!("CreatePlaylist"))
                                     .class(cosmic::widget::button::ButtonClass::Standard)
                                     .on_press(Message::AddToPlaylist)
                                     .into(),
-                                cosmic::widget::button::text("Clear All")
+                                cosmic::widget::button::text(fl!("ClearAll"))
                                     .class(cosmic::widget::button::ButtonClass::Destructive)
                                     .on_press(Message::ClearQueue)
                                     .into(),
@@ -244,7 +245,7 @@ pub fn listify_queue(queue: &Vec<AppTrack>, active: usize) -> Element<'static, M
                                 ))
                                     .on_press(Message::RemoveSongInQueue(index))
                                     .into(),
-                                cosmic::widget::text("Now Playing")
+                                cosmic::widget::text(fl!("NowPlaying"))
                                     .class(cosmic::theme::Text::Accent)
                                     .into(),
                             ])

--- a/src/app/playlists.rs
+++ b/src/app/playlists.rs
@@ -95,7 +95,7 @@ impl PlaylistPage {
                                         } else {
                                             cosmic::widget::container(
                                                 cosmic::widget::icon::from_name(
-                                                    "media-optical-symbolic",
+                                                    "playlist-symbolic",
                                                 )
                                                 .size((model.config.grid_item_size * 32) as u16),
                                             )
@@ -287,7 +287,7 @@ impl PlaylistPage {
                                     } else {
                                         cosmic::widget::container(
                                             cosmic::widget::icon::from_name(
-                                                "media-optical-symbolic",
+                                                "playlist-symbolic",
                                             )
                                                 .size((model.config.grid_item_size * 32) as u16),
                                         )
@@ -417,7 +417,7 @@ fn tracks_listify(tracks: &Vec<PlaylistTrack>) -> Element<'static, Message> {
                             cosmic::widget::text::heading(format!("{}", track.title,)).into(),
                             cosmic::widget::horizontal_space().into(),
                             cosmic::widget::button::icon(cosmic::widget::icon::from_name(
-                                "media-playback-start-symbolic",
+                                "playlist-symbolic",
                             ))
                             .on_press(Message::AddTrackToQueue(
                                 track.path.clone(),

--- a/src/app/playlists.rs
+++ b/src/app/playlists.rs
@@ -87,7 +87,7 @@ impl PlaylistPage {
                                     cosmic::widget::column::with_children(vec![
                                         if let Some(cover_art) = &playlist.thumbnail {
                                             cosmic::widget::container::Container::new(
-                                                cosmic::widget::image(cover_art),
+                                                cosmic::widget::image(cover_art).content_fit(ContentFit::Fill),
                                             )
                                             .height((model.config.grid_item_size * 32) as f32)
                                             .width((model.config.grid_item_size * 32) as f32)
@@ -200,7 +200,7 @@ impl PlaylistPage {
                                         .into()
                                 }
                                 Some(handle) => cosmic::widget::image(handle)
-                                    .content_fit(ContentFit::Contain)
+                                    .content_fit(ContentFit::Fill)
                                     .height(128.0)
                                     .width(128.0)
                                     .into(),

--- a/src/app/playlists.rs
+++ b/src/app/playlists.rs
@@ -224,9 +224,19 @@ impl PlaylistPage {
                                         ))
                                         .into(),
 
+                                    cosmic::widget::row::with_children(vec![
+                                    cosmic::widget::button::icon(cosmic::widget::icon::from_name("edit-symbolic"))
+                                        .on_press(Message::PlaylistEdit(playlist.playlist.path.clone()))
+                                        .class(cosmic::theme::Button::Standard)
+                                        .into(),
+
                                     cosmic::widget::button::icon(cosmic::widget::icon::from_name("user-trash-symbolic"))
                                         .on_press(Message::PlaylistDeleteSafety)
                                         .class(cosmic::theme::Button::Destructive)
+                                        .into(),
+
+                                    ])
+                                        .spacing(cosmic::theme::spacing().space_xxs)
                                         .into(),
 
                                 ])

--- a/src/app/playlists.rs
+++ b/src/app/playlists.rs
@@ -224,8 +224,7 @@ impl PlaylistPage {
                                         ))
                                         .into(),
 
-                                    cosmic::widget::button::text("Delete playlist")
-                                        .leading_icon(cosmic::widget::icon::from_name("window-close-symbolic"))
+                                    cosmic::widget::button::icon(cosmic::widget::icon::from_name("user-trash-symbolic"))
                                         .on_press(Message::PLaylistDeleteSafety)
                                         .class(cosmic::theme::Button::Destructive)
                                         .into(),

--- a/src/app/playlists.rs
+++ b/src/app/playlists.rs
@@ -225,7 +225,7 @@ impl PlaylistPage {
                                         .into(),
 
                                     cosmic::widget::button::icon(cosmic::widget::icon::from_name("user-trash-symbolic"))
-                                        .on_press(Message::PLaylistDeleteSafety)
+                                        .on_press(Message::PlaylistDeleteSafety)
                                         .class(cosmic::theme::Button::Destructive)
                                         .into(),
 
@@ -373,14 +373,14 @@ impl PlaylistPage {
         cosmic::widget::container(
             cosmic::widget::column::with_children(vec![
                 cosmic::widget::row::with_children(vec![
-                    cosmic::widget::text::title2("Album Library")
+                    cosmic::widget::text::title2("Playlists")
                     .width(Length::FillPortion(2))
                     .into(),
                 cosmic::widget::horizontal_space()
                     .width(Length::Shrink)
                     .into(),
                 cosmic::widget::search_input(
-                    "Enter Album Name",
+                    "Enter Playlist Name",
                     model.search_field.as_str(),
                 )
                     .on_input(|input| Message::UpdateSearch(input))

--- a/src/app/playlists.rs
+++ b/src/app/playlists.rs
@@ -6,7 +6,7 @@ use cosmic::widget::{Grid, JustifyContent, Widget};
 use cosmic::{iced, Application, Element, Theme};
 use std::path::PathBuf;
 use std::sync::Arc;
-use crate::app;
+use crate::{app, fl};
 use crate::app::tracks::SearchResult;
 
 #[derive(Debug, Clone)]
@@ -54,7 +54,7 @@ impl PlaylistPage {
 
         body = match &self.playlist_page_state {
             PlaylistPageState::Loading => {
-                cosmic::widget::container(cosmic::widget::text::title2("Loading..."))
+                cosmic::widget::container(cosmic::widget::text::title2(fl!("Loading")))
                     .align_x(Alignment::Center)
                     .align_y(Alignment::Center)
                     .width(Length::Fill)
@@ -185,7 +185,7 @@ impl PlaylistPage {
                         cosmic::widget::button::custom(
                             cosmic::widget::row::with_children(vec![
                                 cosmic::widget::icon::from_name("go-previous-symbolic").into(),
-                                cosmic::widget::text::text("Playlists").into(),
+                                cosmic::widget::text::text(fl!("playlists")).into(),
                             ])
                             .align_y(Alignment::Center),
                         )
@@ -212,7 +212,7 @@ impl PlaylistPage {
                                 cosmic::widget::divider::horizontal::default().into(),
                                 cosmic::widget::row::with_children(vec![
 
-                                    cosmic::widget::button::text("Add to queue")
+                                    cosmic::widget::button::text(fl!("AddToQueue"))
                                         .leading_icon(cosmic::widget::icon::from_name("media-playback-start-symbolic"))
                                         .class(cosmic::theme::Button::Suggested)
                                         .on_press(Message::AddAlbumToQueue(
@@ -373,14 +373,14 @@ impl PlaylistPage {
         cosmic::widget::container(
             cosmic::widget::column::with_children(vec![
                 cosmic::widget::row::with_children(vec![
-                    cosmic::widget::text::title2("Playlists")
+                    cosmic::widget::text::title2(fl!("playlists"))
                     .width(Length::FillPortion(2))
                     .into(),
                 cosmic::widget::horizontal_space()
                     .width(Length::Shrink)
                     .into(),
                 cosmic::widget::search_input(
-                    "Enter Playlist Name",
+                    fl!("PlaylistInputPlaceholder"),
                     model.search_field.as_str(),
                 )
                     .on_input(|input| Message::UpdateSearch(input))
@@ -417,7 +417,7 @@ fn tracks_listify(tracks: &Vec<PlaylistTrack>) -> Element<'static, Message> {
                             cosmic::widget::text::heading(format!("{}", track.title,)).into(),
                             cosmic::widget::horizontal_space().into(),
                             cosmic::widget::button::icon(cosmic::widget::icon::from_name(
-                                "playlist-symbolic",
+                                "media-playback-start-symbolic",
                             ))
                             .on_press(Message::AddTrackToQueue(
                                 track.path.clone(),

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -28,6 +28,8 @@ impl AppModel {
 
         let contain = widget::Container::new(
             widget::column::Column::with_children([
+
+                cosmic::widget::toaster(&self.toasts, cosmic::widget::horizontal_space()).into(),
                 current_settings
                     .title("Current Scan Results")
                     .add(widget::Row::with_children([

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1,9 +1,9 @@
 use crate::app;
+use crate::fl;
 use crate::app::{AppModel, Message};
 use cosmic::widget::text::heading;
 use cosmic::widget::{container, icon, text, ProgressBar};
 use cosmic::{theme, widget, Element};
-use i18n_embed_fl::fl;
 use std::borrow::Cow;
 use std::fmt::format;
 use std::ops::RangeInclusive;
@@ -31,14 +31,14 @@ impl AppModel {
 
                 cosmic::widget::toaster(&self.toasts, cosmic::widget::horizontal_space()).into(),
                 current_settings
-                    .title("Current Scan Results")
+                    .title(fl!("CurrentScanResults"))
                     .add(widget::Row::with_children([
-                        text::heading("Music Directory:").into(),
+                        text::heading(fl!("MusicDirectory") ).into(),
                         widget::horizontal_space().into(),
                         text::text(&self.config.scan_dir).into(),
                     ]))
                     .add(widget::Row::with_children([
-                        text::heading("Files Scanned:").into(),
+                        text::heading(fl!("FilesScanned")).into(),
                         widget::horizontal_space().into(),
                         text::text(format!(
                             "{}/{}",
@@ -49,49 +49,49 @@ impl AppModel {
                         .into(),
                     ]))
                     .add(widget::Row::with_children([
-                        text::heading("Albums Found:").into(),
+                        text::heading(fl!("albums")).into(),
                         widget::horizontal_space().into(),
                         text::text(self.config.albums_found.to_string()).into(),
                     ]))
                     .add(widget::Row::with_children([
-                        text::heading("Tracks Found:").into(),
+                        text::heading(fl!("tracks")).into(),
                         widget::horizontal_space().into(),
                         text::text(self.config.tracks_found.to_string()).into(),
                     ]))
                     .add(widget::Row::with_children([
-                        text::heading("Playlists Found:").into(),
+                        text::heading(fl!("playlists")).into(),
                         widget::horizontal_space().into(),
                         text::text("None").into(),
                     ]))
                     .into(),
                 editable_settings
-                    .title("Music Scanning")
+                    .title(fl!("MusicScanning"))
                     .add(
-                        widget::settings::item::builder("Music Directory:")
-                            .description("Choose directory to scan for music.")
+                        widget::settings::item::builder(fl!("MusicDirectory"))
+                            .description(fl!("firsttimebody"))
                             .control(
                                 match self.rescan_available {
                                     true => {
-                                        cosmic::widget::button::suggested("Select Folder").on_press(Message::ChooseFolder)
+                                        cosmic::widget::button::suggested(fl!("folderselect")).on_press(Message::ChooseFolder)
                                     }
                                     false => {
-                                        cosmic::widget::button::suggested("Select Folder")
+                                        cosmic::widget::button::suggested(fl!("folderselect"))
                                     }
                                 }
 
                             ),
                     )
                     .add(
-                        widget::settings::item::builder("Full Directory Rescan:").control(
+                        widget::settings::item::builder(fl!("FullRescan")).control(
                             match self.rescan_available && !self.config.scan_dir.is_empty() {
                                 true => {
 
-                                    widget::button::text("Rescan")
+                                    widget::button::text(fl!("Rescan"))
                                         .class(widget::button::ButtonClass::Destructive)
                                         .on_press(app::Message::RescanDir)
                                 }
                                 false => {
-                                    widget::button::text("Rescan")
+                                    widget::button::text(fl!("Rescan"))
                                         .class(widget::button::ButtonClass::Destructive)
                                 }
                             }
@@ -101,7 +101,7 @@ impl AppModel {
                     .add(
                         widget::column::Column::with_children([
                             widget::column::Column::with_children([
-                                widget::text::heading("Scan Progress: ").into(),
+                                widget::text::heading(fl!("ScanProgress")).into(),
 
                                 widget::text::caption(format!("{}%", (self.config.files_scanned as f32 /self.config.num_files_found as f32 * 100.0).round()))
                                     .align_x(Horizontal::Right)
@@ -116,9 +116,9 @@ impl AppModel {
                     )
                     .into(),
                 grid_settings
-                    .title("User Interface")
+                    .title(fl!("UserInterface"))
                     .add(
-                        widget::settings::item::builder("Grid Item Size: ")
+                        widget::settings::item::builder(fl!("GridItemSize"))
                             .control(cosmic::widget::slider(1..=6, self.config.grid_item_size, |a| Message::GridSliderChange(a))
                                 
                             )
@@ -126,9 +126,9 @@ impl AppModel {
                     .into(),
 
                 player_settings
-                    .title("Music Player")
+                    .title(fl!("MusicPlayer"))
                     .add(
-                            widget::settings::item::builder(format!("App Volume: {}", self.config.volume.trunc()))
+                            widget::settings::item::builder(fl!("AppVolume", volume = self.config.volume.trunc()))
                             .control(
                                 cosmic::widget::slider(0.0..=100.0, self.config.volume, |a| Message::VolumeSliderChange(a))
 

--- a/src/app/tracks.rs
+++ b/src/app/tracks.rs
@@ -1,4 +1,4 @@
-use crate::app;
+use crate::{app, fl};
 use crate::app::{AppTrack, Message};
 use cosmic::iced::{Alignment, ContentFit, Element, Length};
 use cosmic::iced_core::image::Handle;
@@ -48,13 +48,13 @@ impl TrackPage {
                 cosmic::widget::row::with_children(vec![
                     // HEADING AREA
                     cosmic::widget::row::with_children(vec![
-                        cosmic::widget::text::title2("Track Library")
+                        cosmic::widget::text::title2(fl!("TrackLibrary"))
                             .width(Length::FillPortion(2))
                             .into(),
                         cosmic::widget::horizontal_space()
                             .width(Length::Shrink)
                             .into(),
-                        cosmic::widget::search_input("Enter Track Information", &model.search_field)
+                        cosmic::widget::search_input(fl!("TrackInputPlaceholder"), &model.search_field)
                             .on_input(|a| Message::UpdateSearch(a))
                             .width(Length::FillPortion(1))
                             .into(),
@@ -72,7 +72,7 @@ impl TrackPage {
                 cosmic::widget::scrollable::vertical(
                     cosmic::widget::container(
                     match self.track_page_state {
-                    TrackPageState::Loading => cosmic::widget::text::title3("Loading...").into(),
+                    TrackPageState::Loading => cosmic::widget::text::title3(fl!("Loading")).into(),
                     TrackPageState::Loaded => match self.tracks.is_empty() {
                         true => cosmic::widget::container(
                             cosmic::widget::column::with_children(vec![
@@ -92,15 +92,15 @@ impl TrackPage {
                     TrackPageState::Search => cosmic::widget::column::with_children(vec![
                         cosmic::widget::container(
                             cosmic::widget::row::with_children(vec![
-                                cosmic::widget::text::heading("Search By: ").into(),
+                                cosmic::widget::text::heading(fl!("SearchFilter")).into(),
                                 cosmic::widget::horizontal_space().into(),
-                                cosmic::widget::checkbox("Title", self.search_by_title)
+                                cosmic::widget::checkbox(fl!("title"), self.search_by_title)
                                     .on_toggle(|a| Message::ToggleTitle(a))
                                     .into(),
-                                cosmic::widget::checkbox("Album", self.search_by_album)
+                                cosmic::widget::checkbox(fl!("album"), self.search_by_album)
                                     .on_toggle(|a| Message::ToggleAlbum(a))
                                     .into(),
-                                cosmic::widget::checkbox("Artist", self.search_by_artist)
+                                cosmic::widget::checkbox(fl!("artist"), self.search_by_artist)
                                     .on_toggle(|a| Message::ToggleArtist(a))
                                     .into(),
                             ])
@@ -175,15 +175,15 @@ fn search_list_display<'a>(
     let mut elem_vec : Vec<cosmic::Element<Message>> = Vec::with_capacity(3);
 
     if settings.0 {
-        elem_vec.push(search_group_display(&title_vector, "Title"));
+        elem_vec.push(search_group_display(&title_vector, fl!("title").as_str()));
     }
 
     if settings.1 {
-        elem_vec.push(search_group_display(&album_vector, "Album"));
+        elem_vec.push(search_group_display(&album_vector, fl!("album").as_str()));
     }
 
     if settings.2 {
-        elem_vec.push(search_group_display(&artist_vector, "Artist"));
+        elem_vec.push(search_group_display(&artist_vector, fl!("artist").as_str()));
     }
 
 
@@ -199,7 +199,7 @@ fn search_group_display<'a>(tracks: &Vec<AppTrack>, search_title: &str) -> cosmi
     cosmic::widget::column::with_children(vec![
         cosmic::widget::container(
             cosmic::widget::row::with_children(vec![
-                cosmic::widget::text::heading(format!("By {}", search_title)).into(),
+                cosmic::widget::text::heading(fl!("SearchFilterSpecify", filter = search_title)).into(),
             ])
                 .padding(cosmic::theme::spacing().space_xxs)
                 .width(Length::Fill)

--- a/src/app/tracks.rs
+++ b/src/app/tracks.rs
@@ -48,13 +48,13 @@ impl TrackPage {
                 cosmic::widget::row::with_children(vec![
                     // HEADING AREA
                     cosmic::widget::row::with_children(vec![
-                        cosmic::widget::text::title2("All Tracks")
+                        cosmic::widget::text::title2("Track Library")
                             .width(Length::FillPortion(2))
                             .into(),
                         cosmic::widget::horizontal_space()
                             .width(Length::Shrink)
                             .into(),
-                        cosmic::widget::search_input("Enter Track Title", &model.search_field)
+                        cosmic::widget::search_input("Enter Track Information", &model.search_field)
                             .on_input(|a| Message::UpdateSearch(a))
                             .width(Length::FillPortion(1))
                             .into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,12 +5,11 @@ use cosmic::cosmic_config::{self, cosmic_config_derive::CosmicConfigEntry, Cosmi
 use cosmic::Application;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Default, Clone, CosmicConfigEntry, PartialEq)]
+#[derive(Debug, Clone, CosmicConfigEntry, PartialEq)]
 #[version = 1]
 pub struct Config {
     pub scan_dir: String,
     pub grid_item_size: u32,
-    pub grid_item_spacing: u32,
     pub num_files_found: u32,
     pub files_scanned: u32,
     pub tracks_found: u32,
@@ -32,6 +31,19 @@ impl Config {
                 log::error!("{}", e);
                 (None, Config::default())
             }
+        }
+    }
+}
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            scan_dir: "".to_string(),
+            grid_item_size: 3,
+            num_files_found: 0,
+            files_scanned: 0,
+            tracks_found: 0,
+            albums_found: 0,
+            volume: 100.0,
         }
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -114,7 +114,7 @@ pub fn create_database() {
     .unwrap();
 }
 //todo: Theres probably a better way to do this.
-pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
+pub async fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
     let conn = rusqlite::Connection::open(
         dirs::data_local_dir().unwrap().join(crate::app::AppModel::APP_ID).join("nova_music.db")
     ).unwrap();
@@ -153,22 +153,22 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                 StandardTagKey::AcoustidId => {}
                 StandardTagKey::Album => match tag.value {
                     Value::String(name) => {
-                        log::info!("This file maay be a part of an album!");
+                        // log::info!("This file maay be a part of an album!");
                         album.name = name;
                     }
                     _ => {
-                        log::error!("Album name is not a string");
+                        // log::error!("Album name is not a string");
                     }
                 },
                 StandardTagKey::AlbumArtist => match tag.value {
                     Value::String(name) => {
                         match conn.execute("INSERT INTO artists (name) VALUES (?)", [&name]) {
                             Ok(_) => {
-                                log::info!("Added artist {} to artists", name);
+                                // log::info!("Added artist {} to artists", name);
                                 album.artist_id = conn.last_insert_rowid() as u64;
                             }
                             Err(_) => {
-                                log::warn!("Artist: {} already created", name);
+                                // log::warn!("Artist: {} already created", name);
                                 album.artist_id =
                                     conn.query_row(
                                         "SELECT id FROM artists WHERE name = ?",
@@ -176,7 +176,7 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                                         |row| row.get::<usize, u32>(0),
                                     )
                                     .unwrap() as u64;
-                                log::info!("ARTIST ID:  {}", album.artist_id);
+                                // log::info!("ARTIST ID:  {}", album.artist_id);
                             }
                         }
                     }
@@ -188,7 +188,7 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                         artist.name = Some(name);
                     }
                     _ => {
-                        log::error!("Artist name is not a string");
+                        // log::error!("Artist name is not a string");
                     }
                 },
                 StandardTagKey::Bpm => {}
@@ -202,7 +202,7 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                 StandardTagKey::Description => {}
                 StandardTagKey::DiscNumber => match tag.value {
                     Value::String(val) => {
-                        log::info!("DISC NUMBER");
+                        // log::info!("DISC NUMBER");
                         let mut final_val = val;
 
                         if final_val.contains("/") {
@@ -219,11 +219,11 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                             .expect(format!("Invalid track number: {}", final_val).as_str());
                     }
                     Value::UnsignedInt(val) => {
-                        log::info!("{}: {}", "DISC NUMBER unsigned int".red(), val);
+                        // log::info!("{}: {}", "DISC NUMBER unsigned int".red(), val);
                         album_tracks.disc_number = val
                     }
                     _ => {
-                        log::error!("DISC NUMBER");
+                        // log::error!("DISC NUMBER");
                     }
 
                 },
@@ -231,7 +231,7 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                 StandardTagKey::DiscTotal => match tag.value {
                     Value::String(val) => album.num_of_discs = val.parse::<u64>().unwrap(),
                     _ => {
-                        log::error!("Disc number is not a number");
+                        // log::error!("Disc number is not a number");
                     }
                 },
                 StandardTagKey::EncodedBy => {}
@@ -330,21 +330,21 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                     }
 
                     Value::Binary(_) => {
-                        log::info!("{}", "TRACK NUMBER binary".red());
+                        // log::info!("{}", "TRACK NUMBER binary".red());
                     }
                     Value::Boolean(_) => {
-                        log::info!("{}", "TRACK NUMBER  boolean".red());
+                        // log::info!("{}", "TRACK NUMBER  boolean".red());
                     }
                     Value::Flag => {
-                        log::info!("{}", "TRACK NUMBER  flag".red());
+                        // log::info!("{}", "TRACK NUMBER  flag".red());
 
                     }
                     Value::Float(_) => {
-                        log::info!("{}", "TRACK NUMBER  float".red());
+                        // log::info!("{}", "TRACK NUMBER  float".red());
 
                     }
                     Value::SignedInt(_) => {
-                        log::info!("{}", "TRACK NUMBER  signed int".red());
+                        // log::info!("{}", "TRACK NUMBER  signed int".red());
 
                     }
                 },
@@ -354,7 +354,7 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                         track.name = Some(name);
                     }
                     _ => {
-                        log::error!("Track name is not a string");
+                        // log::error!("Track name is not a string");
                     }
                 },
                 StandardTagKey::TrackTotal => match tag.value {
@@ -362,7 +362,7 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                         album.num_of_tracks = val.parse::<u64>().unwrap();
                     }
                     _ => {
-                        log::error!("Track number is not a number");
+                        // log::error!("Track number is not a number");
                     }
                 },
                 StandardTagKey::TvEpisode => {}
@@ -389,11 +389,11 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
     match artist.name {
         Some(name) => match conn.execute("INSERT INTO artists (name) VALUES (?)", [&name]) {
             Ok(_) => {
-                log::info!("Added artist {} to artists", name);
+                // log::info!("Added artist {} to artists", name);
                 artist.id = conn.last_insert_rowid() as u64;
             }
             Err(_) => {
-                log::warn!("Artist: {} already created", name);
+                // log::warn!("Artist: {} already created", name);
                 artist.id = conn
                     .query_row("SELECT id FROM artists WHERE name = ?", &[&name], |row| {
                         row.get::<usize, u32>(0)
@@ -402,7 +402,7 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
             }
         },
         None => {
-            log::error!("Artist name is None");
+            // log::error!("Artist name is None");
         }
     }
 
@@ -414,31 +414,31 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
 
     track.id = conn.last_insert_rowid() as u64;
 
-    log::info!("{}", album.name.on_red());
+    // log::info!("{}", album.name.on_red());
     if album.name.is_empty() {
     } else {
         // If album already exists, no need to add extra info
-        log::info!("Looking to insert {}", album.name);
+        // log::info!("Looking to insert {}", album.name);
         match conn.query_row(
             "select id from album where name = ?",
             &[&album.name],
             |row| row.get::<usize, u32>(0),
         ) {
             Ok(val) => {
-                log::info!(
-                    "Album with title, {}, found \n {}",
-                    album.name.white().on_blue().bold(),
-                    val
-                );
+                // log::info!(
+                //     "Album with title, {}, found \n {}",
+                //     album.name.white().on_blue().bold(),
+                //     val
+                // );
                 // Album already exists
                 album.id = val
             }
             Err(err) => {
-                log::info!(
-                    "No album with title, {}, found; Creating a new one \n ------ \n {}",
-                    album.name.white().on_blue().bold(),
-                    err.to_string()
-                );
+                // log::info!(
+                //     "No album with title, {}, found; Creating a new one \n ------ \n {}",
+                //     album.name.white().on_blue().bold(),
+                //     err.to_string()
+                // );
                 // Album does not exist yet
                 if let Some(visual) = find_visual(filepath) {
                     //If visual data exists
@@ -447,10 +447,10 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                         (&album.name, &album.num_of_discs, &album.num_of_tracks, &album.artist_id, &visual),
                     ) {
                         Ok(_) => {
-                            log::info!("{}", "Added album with some visual!".green());
+                            // log::info!("{}", "Added album with some visual!".green());
                         }
                         Err(_) => {
-                            log::error!("{}", "UNABLE TO INSERT ALBUM DATA W/ VISUAL".red());
+                            // log::error!("{}", "UNABLE TO INSERT ALBUM DATA W/ VISUAL".red());
                         }
                     }
                 } else {
@@ -460,10 +460,10 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
                         (&album.name, &album.num_of_discs, &album.num_of_tracks, &album.artist_id, None::<Box<[u8]>>),
                     ) {
                         Ok(_) => {
-                            log::info!("{}", "Added album without visual!".purple());
+                            // log::info!("{}", "Added album without visual!".purple());
                         }
                         Err(err) => {
-                            log::error!("{} \n {}", "UNABLE TO INSERT ALBUM DATA W/O VISUAL".red(), err.to_string());
+                            // log::error!("{} \n {}", "UNABLE TO INSERT ALBUM DATA W/O VISUAL".red(), err.to_string());
 
                         }
                     }
@@ -480,7 +480,7 @@ pub fn create_database_entry(metadata_tags: Vec<Tag>, filepath: &PathBuf) {
 
             }
             Err(err) => {
-                log::error!("album_track insertion went wrong \n ------ \n  {}", err.to_string());
+                // log::error!("album_track insertion went wrong \n ------ \n  {}", err.to_string());
             }
         }
     }
@@ -508,11 +508,11 @@ fn find_visual(filepath: &PathBuf) -> Option<Box<[u8]>> {
         if let Some(mdat_rev) = mdat_rev.current() {
             match mdat_rev.visuals().get(0) {
                 Some(visual) => {
-                    log::info!("This album contains visual data!");
+                    // log::info!("This album contains visual data!");
                     Some(visual.data.clone())
                 }
                 None => {
-                    log::info!("This album contains no visual data!");
+                    // log::info!("This album contains no visual data!");
                     None
                 }
             }

--- a/src/database.rs
+++ b/src/database.rs
@@ -41,16 +41,8 @@ struct AlbumTracks {
     disc_number: u64,
 }
 
-struct Playlist {
-    id: u64,
-    name: String,
-}
 
-struct PlaylistTracks {
-    id: u64,
-    playlist_id: u64,
-    track_id: u64,
-}
+
 
 pub fn create_database() {
     let conn = rusqlite::Connection::open(
@@ -77,34 +69,6 @@ pub fn create_database() {
         [],
     )
     .unwrap();
-
-    conn.execute(
-        "
-        CREATE TABLE IF NOT EXISTS playlists (
-            id INTEGER PRIMARY KEY,
-            name TEXT,
-            track_number INTEGER,
-            album_cover BLOB
-        )",
-        [],
-    )
-        .unwrap();
-
-    conn.execute(
-        "
-    CREATE TABLE IF NOT EXISTS playlist_tracks (
-        id INTEGER PRIMARY KEY,
-        track_id INTEGER,
-        playlist_id INTEGER,
-        FOREIGN KEY(playlist_id) REFERENCES playlists(id),
-        FOREIGN KEY(track_id) REFERENCES tracks(id)
-    )",
-        [],
-    )
-        .unwrap();
-
-
-
 
     conn.execute(
         "


### PR DESCRIPTION
Updates
- Playlists now stored in local data directory as utf8 m3u files.
- Creating a playlist allows you to choose and icon to display. (Filepath to icon is saved in the M3U)
- When scanning the music directory, Nova Music will detect m3u files and make a copy in the local data directory.
- The user is now notified in the case of most errors rather than doing nothing or crashing.
- All the text in the app is now utilizing localization with i18n so translations are now possible.